### PR TITLE
post review only when comments are there

### DIFF
--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -226,6 +226,9 @@ ${COMMENT_TAG}`
   }
 
   async submitReview(pullNumber: number, commitId: string) {
+    if (this.reviewCommentsBuffer.length === 0) {
+      return
+    }
     for (const comment of this.reviewCommentsBuffer) {
       const comments = await this.getCommentsAtRange(
         pullNumber,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Added an early return in `submitReview` function of `src/commenter.ts` when there are no review comments, improving efficiency by avoiding unnecessary operations.

> 🎉 Here's to the code that's lean and mean,
> No more wasted cycles, it's a well-oiled machine. 🚀
> When comments are none, it knows what to shun,
> Celebrating small wins, this battle is won! 🏆
<!-- end of auto-generated comment: release notes by openai -->