### PR TITLE
do not retry on secondary limits

### DIFF
--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -1,4 +1,4 @@
-import {getInput, warning} from '@actions/core'
+import {getInput} from '@actions/core'
 import {Octokit} from '@octokit/action'
 import {retry} from '@octokit/plugin-retry'
 import {throttling} from '@octokit/plugin-throttling'
@@ -13,26 +13,24 @@ export const octokit = new RetryAndThrottlingOctokit({
     onRateLimit: (
       retryAfter: number,
       options: any,
-      _o: any,
+      _o: typeof Octokit,
       retryCount: number
     ) => {
-      warning(
+      console.log(
         `Request quota exhausted for request ${options.method} ${options.url}
 Retry after: ${retryAfter} seconds
 Retry count: ${retryCount}
 `
       )
-      return true
+      if (retryCount <= 3) {
+        console.log(`Retrying after ${retryAfter} seconds!`)
+        return true
+      }
     },
-    onSecondaryRateLimit: (_retryAfter: number, options: any) => {
-      warning(
-        `SecondaryRateLimit detected for request ${options.method} ${options.url}`
+    onSecondaryRateLimit: (retryAfter: number, options: any) => {
+      console.log(
+        `SecondaryRateLimit detected for request ${options.method} ${options.url} ; retry after ${retryAfter} seconds`
       )
-      return true
     }
-  },
-  retry: {
-    doNotRetry: ['429'],
-    maxRetries: 3
   }
 })


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Replaced `warning` import with a `console.log` statement in `src/octokit.ts`.
- Added a condition to check the retry count before logging and returning `true`.
- Updated `onSecondaryRateLimit` function to log rate limit information directly.
- Removed the `retry` configuration object.

> 🎉 Here's to the code that's leaner, not meaner,
> To the logs that are clearer, making debugging no fearer. 
> With each retry counted, and rate limits mounted,
> We've refactored and pruned, and a victory is sounded! 🥳
<!-- end of auto-generated comment: release notes by openai -->