### PR TITLE
retry on secondary limits except when submitting batched review

### DIFF
--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -31,6 +31,14 @@ Retry count: ${retryCount}
       warning(
         `SecondaryRateLimit detected for request ${options.method} ${options.url} ; retry after ${retryAfter} seconds`
       )
+      // if we are doing a POST method on /repos/{owner}/{repo}/pulls/{pull_number}/reviews then we shouldn't retry
+      if (
+        options.method === 'POST' &&
+        options.url.match(/\/repos\/.*\/.*\/pulls\/.*\/reviews/)
+      ) {
+        return false
+      }
+      return true
     }
   }
 })


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
### Bug fix:
- Added a condition to prevent retrying a POST request on a specific endpoint related to pull request reviews. This change enhances the efficiency of our system by avoiding unnecessary retries.

> 🎉 No more retries, no more waits, 🕐
> On pull requests, we've closed the gates. 🚪
> With this fix, we take a bow, 🙇‍♂️
> Smoother reviews, we have now! 🥳
```
<!-- end of auto-generated comment: release notes by openai -->