### PR TITLE
openai -> coderabbit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 <div>
-    <a href="https://github.com/coderabbitai/openai-pr-reviewer)/commits/main">
-    <img alt="GitHub" src="https://img.shields.io/github/last-commit/coderabbitai/openai-pr-reviewer/main?style=for-the-badge" height="20">
+    <a href="https://github.com/coderabbitai/ai-pr-reviewer)/commits/main">
+    <img alt="GitHub" src="https://img.shields.io/github/last-commit/coderabbitai/ai-pr-reviewer/main?style=for-the-badge" height="20">
     </a>
     </div>
 
@@ -47,7 +47,7 @@ FAQs, you can refer to the sections below.
 
 - [Overview](#overview)
 - [Install instructions](#install-instructions)
-- [Conversation with OpenAI](#conversation-with-openai)
+- [Conversation with CodeRabbit](#conversation-with-coderabbit)
 - [Examples](#examples)
 - [Contribute](#contribute)
 - [FAQs](#faqs)
@@ -55,7 +55,7 @@ FAQs, you can refer to the sections below.
 ## Install instructions
 
 `ai-pr-reviewer` runs as a GitHub Action. Add the below file to your repository
-at `.github/workflows/openai-pr-reviewer.yml`
+at `.github/workflows/ai-pr-reviewer.yml`
 
 ```yaml
 name: Code Review
@@ -123,7 +123,7 @@ value. For example, to review docs/blog posts, you can use the following prompt:
 
 ```yaml
 system_message: |
-  You are `@openai` (aka `github-actions[bot]`), a language model
+  You are `@coderabbitai` (aka `github-actions[bot]`), a language model
   trained by OpenAI. Your purpose is to act as a highly experienced
   DevRel (developer relations) professional with focus on cloud-native
   infrastructure.
@@ -150,15 +150,15 @@ system_message: |
 
 </details>
 
-## Conversation with OpenAI
+## Conversation with CodeRabbit
 
 You can reply to a review comment made by this action and get a response based
 on the diff context. Additionally, you can invite the bot to a conversation by
-tagging it in the comment (`@openai`).
+tagging it in the comment (`@coderabbitai`).
 
 Example:
 
-> @openai Please generate a test plan for this file.
+> @coderabbitai Please generate a test plan for this file.
 
 Note: A review comment is a comment made on a diff or a file in the pull
 request.
@@ -170,7 +170,7 @@ to review documentation, you can ignore PRs that only change the documentation.
 To ignore a PR, add the following keyword in the PR description:
 
 ```text
-@openai: ignore
+@coderabbitai: ignore
 ```
 
 ## Examples

--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ inputs:
     required: false
     description: 'System message to be sent to OpenAI'
     default: |
-      You are `@openai` (aka `github-actions[bot]`), a language model 
+      You are `@coderabbitai` (aka `github-actions[bot]`), a language model 
       trained by OpenAI. Your purpose is to act as a highly experienced 
       software engineer and provide a thorough review of the code hunks
       and suggest code snippets to improve key areas such as:

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
-name: 'OpenAI ChatGPT based PR Reviewer & Summarizer'
-description: 'OpenAI ChatGPT based PR Reviewer and Summarizer'
+name: 'AI-based PR Reviewer & Summarizer with Chat Capabilities'
+description: 'AI-based PR Reviewer & Summarizer with Chat Capabilities'
 branding:
-  icon: 'aperture'
+  icon: 'git-merge'
   color: 'orange'
-author: 'FluxNinja, Inc.'
+author: 'CodeRabbit LLC'
 inputs:
   debug:
     required: false

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -563,13 +563,19 @@ ${chain}
   async create(body: string, target: number) {
     try {
       // get comment ID from the response
-      await octokit.issues.createComment({
+      const response = await octokit.issues.createComment({
         owner: repo.owner,
         repo: repo.repo,
         // eslint-disable-next-line camelcase
         issue_number: target,
         body
       })
+      // add comment to issueCommentsCache
+      if (this.issueCommentsCache[target]) {
+        this.issueCommentsCache[target].push(response.data)
+      } else {
+        this.issueCommentsCache[target] = [response.data]
+      }
     } catch (e) {
       warning(`Failed to create comment: ${e}`)
     }

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -7,34 +7,40 @@ import {octokit} from './octokit'
 const context = github_context
 const repo = context.repo
 
-export const COMMENT_GREETING = ':robot: OpenAI'
+export const COMMENT_GREETING = `<img src="https://avatars.githubusercontent.com/in/347564?s=41" alt="Image description" width="20" height="20">   CodeRabbit`
 
 export const COMMENT_TAG =
-  '<!-- This is an auto-generated comment by OpenAI -->'
+  '<!-- This is an auto-generated comment by CodeRabbit -->'
 
 export const COMMENT_REPLY_TAG =
-  '<!-- This is an auto-generated reply by OpenAI -->'
+  '<!-- This is an auto-generated reply by CodeRabbit -->'
 
 export const SUMMARIZE_TAG =
-  '<!-- This is an auto-generated comment: summarize by openai -->'
+  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->'
+
+export const IN_PROGRESS_START_TAG =
+  '<!-- This is an auto-generated comment: summarize review in progress by coderabbit.ai -->'
+
+export const IN_PROGRESS_END_TAG =
+  '<!-- end of auto-generated comment: summarize review in progress by coderabbit.ai -->'
 
 export const DESCRIPTION_START_TAG = `
-<!-- This is an auto-generated comment: release notes by openai -->`
+<!-- This is an auto-generated comment: release notes by coderabbit.ai -->`
 export const DESCRIPTION_END_TAG =
-  '<!-- end of auto-generated comment: release notes by openai -->'
+  '<!-- end of auto-generated comment: release notes by coderabbit.ai -->'
 
-export const RAW_SUMMARY_START_TAG = `<!-- This is an auto-generated comment: raw summary by openai -->
+export const RAW_SUMMARY_START_TAG = `<!-- This is an auto-generated comment: raw summary by coderabbit.ai -->
 <!--
 `
 export const RAW_SUMMARY_END_TAG = `-->
-<!-- end of auto-generated comment: raw summary by openai -->`
+<!-- end of auto-generated comment: raw summary by coderabbit.ai -->`
 
-export const SHORT_SUMMARY_START_TAG = `<!-- This is an auto-generated comment: short summary by openai -->
+export const SHORT_SUMMARY_START_TAG = `<!-- This is an auto-generated comment: short summary by coderabbit.ai -->
 <!--
 `
 
 export const SHORT_SUMMARY_END_TAG = `-->
-<!-- end of auto-generated comment: short summary by openai -->`
+<!-- end of auto-generated comment: short summary by coderabbit.ai -->`
 
 export const COMMIT_ID_START_TAG = '<!-- commit_ids_reviewed_start -->'
 export const COMMIT_ID_END_TAG = '<!-- commit_ids_reviewed_end -->'
@@ -717,5 +723,49 @@ ${chain}
     }
 
     return allCommits
+  }
+
+  // add in-progress status to the comment body
+  addInProgressStatus(
+    commentBody: string,
+    headCommitId: string,
+    highestReviewedCommitId: string
+  ): string {
+    const start = commentBody.indexOf(IN_PROGRESS_START_TAG)
+    const end = commentBody.indexOf(IN_PROGRESS_END_TAG)
+    // add to the beginning of the comment body if the marker doesn't exist
+    // otherwise do nothing
+    if (start === -1 || end === -1) {
+      return `${IN_PROGRESS_START_TAG}
+
+Currently reviewing new changes in this PR...
+
+<details>
+<summary>Details</summary>
+The files that changed from the \`base\` of the PR and between \`${highestReviewedCommitId}\` and \`${headCommitId}\` commits are being reviewed.
+</details>
+
+${IN_PROGRESS_END_TAG}
+
+---
+
+${commentBody}`
+    }
+    return commentBody
+  }
+
+  // remove in-progress status from the comment body
+  removeInProgressStatus(commentBody: string): string {
+    const start = commentBody.indexOf(IN_PROGRESS_START_TAG)
+    const end = commentBody.indexOf(IN_PROGRESS_END_TAG)
+    // remove the in-progress status if the marker exists
+    // otherwise do nothing
+    if (start !== -1 && end !== -1) {
+      return (
+        commentBody.substring(0, start) +
+        commentBody.substring(end + IN_PROGRESS_END_TAG.length)
+      )
+    }
+    return commentBody
   }
 }

--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -17,7 +17,7 @@ import {getTokenCount} from './tokenizer'
 // eslint-disable-next-line camelcase
 const context = github_context
 const repo = context.repo
-const ASK_BOT = '@openai'
+const ASK_BOT = '@coderabbitai'
 
 export const handleReviewComment = async (
   heavyBot: Bot,

--- a/src/review.ts
+++ b/src/review.ts
@@ -162,7 +162,7 @@ export const codeReview = async (
   const commits = incrementalDiff.data.commits
 
   if (commits.length === 0) {
-    warning('Skipped: ommits is null')
+    warning('Skipped: commits is null')
     return
   }
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -402,7 +402,7 @@ ${filename}: ${summary}
     if (releaseNotesResponse === '') {
       info('release notes: nothing obtained from openai')
     } else {
-      let message = '### Summary by CodeRabbit\n\n'
+      let message = '### Summary by CodeRabbit OSS\n\n'
       message += releaseNotesResponse
       try {
         await commenter.updateDescription(

--- a/src/review.ts
+++ b/src/review.ts
@@ -22,7 +22,7 @@ import {getTokenCount} from './tokenizer'
 const context = github_context
 const repo = context.repo
 
-const ignoreKeyword = '@openai: ignore'
+const ignoreKeyword = '@coderabbitai: ignore'
 
 export const codeReview = async (
   lightBot: Bot,
@@ -72,11 +72,13 @@ export const codeReview = async (
     context.payload.pull_request.number
   )
   let existingCommitIdsBlock = ''
+  let existingSummarizeCmtBody = ''
   if (existingSummarizeCmt != null) {
-    inputs.rawSummary = commenter.getRawSummary(existingSummarizeCmt.body)
-    inputs.shortSummary = commenter.getShortSummary(existingSummarizeCmt.body)
+    existingSummarizeCmtBody = existingSummarizeCmt.body
+    inputs.rawSummary = commenter.getRawSummary(existingSummarizeCmtBody)
+    inputs.shortSummary = commenter.getShortSummary(existingSummarizeCmtBody)
     existingCommitIdsBlock = commenter.getReviewedCommitIdsBlock(
-      existingSummarizeCmt.body
+      existingSummarizeCmtBody
     )
   }
 
@@ -140,13 +142,6 @@ export const codeReview = async (
     return
   }
 
-  const commits = incrementalDiff.data.commits
-
-  if (commits.length === 0) {
-    warning('Skipped: ommits is null')
-    return
-  }
-
   // skip files if they are filtered out
   const filterSelectedFiles = []
   const filterIgnoredFiles = []
@@ -157,6 +152,18 @@ export const codeReview = async (
     } else {
       filterSelectedFiles.push(file)
     }
+  }
+
+  if (filterSelectedFiles.length === 0) {
+    warning('Skipped: filterSelectedFiles is null')
+    return
+  }
+
+  const commits = incrementalDiff.data.commits
+
+  if (commits.length === 0) {
+    warning('Skipped: ommits is null')
+    return
   }
 
   // find hunks to review
@@ -254,6 +261,16 @@ ${hunks.oldHunk}
     error('Skipped: no files to review')
     return
   }
+
+  // update the existing comment with in progress status
+  const inProgressSummarizeCmt = commenter.addInProgressStatus(
+    existingSummarizeCmtBody,
+    context.payload.pull_request.head.sha,
+    highestReviewedCommitId
+  )
+
+  // add in progress status to the summarize comment
+  await commenter.comment(`${inProgressSummarizeCmt}`, SUMMARIZE_TAG, 'replace')
 
   const summariesFailed: string[] = []
 
@@ -385,7 +402,7 @@ ${filename}: ${summary}
     if (releaseNotesResponse === '') {
       info('release notes: nothing obtained from openai')
     } else {
-      let message = '### Summary by OpenAI\n\n'
+      let message = '### Summary by CodeRabbit\n\n'
       message += releaseNotesResponse
       try {
         await commenter.updateDescription(
@@ -412,20 +429,24 @@ ${RAW_SUMMARY_END_TAG}
 ${SHORT_SUMMARY_START_TAG}
 ${inputs.shortSummary}
 ${SHORT_SUMMARY_END_TAG}
+
 ---
 
-### Chat with 🤖 OpenAI Bot (\`@openai\`)
+<details>
+<summary>Notes</summary>
+
+### Chat with <img src="https://avatars.githubusercontent.com/in/347564?s=41" alt="Image description" width="20" height="20">  CodeRabbit Bot (\`@coderabbitai\`)
 - Reply on review comments left by this bot to ask follow-up questions. A review comment is a comment on a diff or a file.
-- Invite the bot into a review comment chain by tagging \`@openai\` in a reply.
+- Invite the bot into a review comment chain by tagging \`@coderabbitai\` in a reply.
 
 ### Code suggestions
 - The bot may make code suggestions, but please review them carefully before committing since the line number ranges may be misaligned. 
 - You can edit the comment made by the bot and manually tweak the suggestion if it is slightly off.
 
 ### Ignoring further reviews
-- Type \`@openai: ignore\` anywhere in the PR description to ignore further reviews from the bot.
+- Type \`@coderabbitai: ignore\` anywhere in the PR description to ignore further reviews from the bot.
 
----
+</details>
 
 ${
   filterIgnoredFiles.length > 0
@@ -653,11 +674,6 @@ ${commentChain}
     await Promise.all(reviewPromises)
 
     summarizeComment += `
----
-In the recent run, only the files that changed from the \`base\` of the PR and between \`${highestReviewedCommitId}\` and \`${
-      context.payload.pull_request.head.sha
-    }\` commits were reviewed.
-
 ${
   reviewsFailed.length > 0
     ? `<details>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Updated all references from `openai` to `coderabbit` in URLs, file paths, and conversation prompts.
- Renamed the GitHub PR Reviewer and Summarizer tool to "AI-based PR Reviewer & Summarizer with Chat Capabilities".
- Changed the branding icon and updated the author information.
- Introduced new tags for in-progress status and added functions to handle these statuses.
- Modified the bot mention used in the codebase from '@openai' to '@coderabbitai'.
- Updated summary messages to indicate they are generated by CodeRabbit instead of OpenAI.

> 🎉 Here's to a new dawn, a fresh start, 🌅  
> With CodeRabbit hopping, playing its part. 🐇  
> No longer OpenAI, but still just as smart, 🧠  
> We've refactored, rebranded, given it a new heart. ❤️  
> So let's celebrate this change, this brand-new chart! 🥳🎈
<!-- end of auto-generated comment: release notes by coderabbit.ai -->