### PR TITLE
Fix tokens calculation & cleanup the file summary prompt logic

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -320,26 +320,22 @@ ${
     }
 
     ins.filename = filename
+    ins.fileDiff = fileDiff
 
     // render prompt based on inputs so far
-    let tokens = getTokenCount(
-      prompts.renderSummarizeFileDiff(ins, options.reviewSimpleChanges)
-    )
+    const summarizePrompt = prompts.renderSummarizeFileDiff(ins, options.reviewSimpleChanges)
+    let tokens = getTokenCount(summarizePrompt)
 
-    const diffTokens = getTokenCount(fileDiff)
-    if (tokens + diffTokens > options.lightTokenLimits.requestTokens) {
+    if (tokens > options.lightTokenLimits.requestTokens) {
       info(`summarize: diff tokens exceeds limit, skip ${filename}`)
       summariesFailed.push(`${filename} (diff tokens exceeds limit)`)
       return null
     }
 
-    ins.fileDiff = fileDiff
-    tokens += fileDiff.length
-
     // summarize content
     try {
       const [summarizeResp] = await lightBot.chat(
-        prompts.renderSummarizeFileDiff(ins, options.reviewSimpleChanges),
+        summarizePrompt,
         {}
       )
 


### PR DESCRIPTION
Previously, the `tokens` calculation was incorrect. With this PR, now it is correctly calculated & reuse the instantiated prompt for readability and efficiency.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
**Bug fix:**
- Fixed the incorrect calculation of `tokens` in `src/review.ts`.
- Improved code readability and efficiency by reusing instantiated prompt.
- Removed diff tokens check, now only checking if token count exceeds limit.
- Files exceeding token limit are now skipped and logged in `summariesFailed`.

> 🎉 Code's been tweaked, bugs have been fixed, 🐛
> Efficiency improved, with no tricks. 🎩✨
> Tokens counted right, no more plight, 🧮
> Celebrate this PR, it's quite a sight! 🥳🎊
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->