### PR TITLE
Add option bot_icon

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -234,6 +234,10 @@ inputs:
     required: false
     description: ISO code for the response language
     default: en-US
+  bot_icon:
+    required: false
+    description: 'The icon for the bot'
+    default: '<img src="https://avatars.githubusercontent.com/in/347564?s=41" alt="Image description" width="20" height="20">'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -1,4 +1,4 @@
-import {info, warning} from '@actions/core'
+import {getInput, info, warning} from '@actions/core'
 // eslint-disable-next-line camelcase
 import {context as github_context} from '@actions/github'
 import {octokit} from './octokit'
@@ -7,7 +7,7 @@ import {octokit} from './octokit'
 const context = github_context
 const repo = context.repo
 
-export const COMMENT_GREETING = `<img src="https://avatars.githubusercontent.com/in/347564?s=41" alt="Image description" width="20" height="20">   CodeRabbit`
+export const COMMENT_GREETING = `${getInput('bot_icon')}   CodeRabbit`
 
 export const COMMENT_TAG =
   '<!-- This is an auto-generated comment by OSS CodeRabbit -->'


### PR DESCRIPTION
Modify the icon and image dimensions to be customizable, since the icons displayed in Coderabbit's Slack notifications are excessively large and clutter the screen.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a new optional input parameter `bot_icon` to the GitHub Action workflow. This allows users to customize the icon displayed in Slack notifications sent by the bot. The default value remains as the pre-defined image tag, ensuring backward compatibility for existing users who do not specify this new parameter.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->